### PR TITLE
feat: add options menu with custom toot filtering

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -2,10 +2,12 @@
 @import '/css/base.css';
 @import '/css/icons.css';
 @import '/css/modal.css';
+@import 'options.css';
 
 /*
  * comma between selector means both
  * space between two means parent-child relation
+ * https://www.w3schools.com/cssref/css_selectors.php
  */
 
 a {
@@ -63,7 +65,7 @@ li {
   margin-top: 0.1em;
 }
 
-#btn_about {
+.nav_right {
   float: right;
 }
 
@@ -226,3 +228,4 @@ button.active .svg_icon:hover {
 .svg_button_like_active {
   fill: var(--color_blue);
 }
+

--- a/public/css/options.css
+++ b/public/css/options.css
@@ -1,0 +1,89 @@
+
+#options_container {
+  visibility: hidden;
+  padding: 0;
+  height: 0;
+  margin: -1px 0; /* so it doesn't take extra height for the border */
+  overflow: hidden;
+  transition: height .5s ease, visibility .5s ease;
+}
+
+#options_container.show {
+  visibility: visible;
+  height: 11.5em;
+}
+
+.check_option {
+  margin: 12px 16px;
+}
+
+.switch {
+  display: inline-block;
+  height: 24px;
+  position: relative;
+  width: 45px;
+}
+
+.switch input {
+  clip: rect(0 0 0 0);
+  outline: none;
+}
+
+.switch input:focus + .slider.round {
+  outline: solid;
+  transition: none;
+}
+
+.slider {
+  background-color: #ccc;
+  bottom: 0;
+  cursor: pointer;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: all .4s ease, visibility 0s;
+}
+
+
+/* slider button part */
+.slider:before {
+  background-color: #fff;
+  bottom: 3px;
+  content: "";
+  height: 18px;
+  left: 4px;
+  position: absolute;
+  transition: all .4s ease, visibility 0s;
+  width: 18px;
+}
+
+input:checked + .slider {
+  background-color: #66bb6a;
+}
+
+input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
+.slider.round {
+  border-radius: 34px;
+}
+
+
+.slider.round:before {
+  border-radius: 50%;
+}
+
+.switch_label {
+	left: 60px;
+	display: block;
+	position: absolute;
+	width: 150px;
+	top: 0;
+}
+
+
+#btn_apply_options {
+  margin: 0.3em;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -46,14 +46,55 @@
         <circle cx="19" cy="5" r="2"/>
       </g>
 
+      <g id="svg_icon_options">
+        <path id="svg_4" d="m10.68477,13.42187l12.69023,0l0,-2.84375l-12.69023,0c-0.6043,-1.6707 -2.16836,-2.84375 -4.0168,-2.84375s-3.4125,1.17305 -4.0168,2.84375l-2.02617,0l0,2.84375l2.02617,0c0.6043,1.6707 2.16836,2.84375 4.0168,2.84375s3.4125,-1.17305 4.0168,-2.84375zm-5.43867,-1.42187c0,-0.78203 0.63984,-1.42187 1.42187,-1.42187s1.42187,0.63984 1.42187,1.42187s-0.63984,1.42187 -1.42187,1.42187s-1.42187,-0.63984 -1.42187,-1.42187z"/>
+        <path id="svg_7" d="m14.48828,23.375c1.84844,0 3.4125,-1.17305 4.0168,-2.84375l4.86992,0l0,-2.84375l-4.86992,0c-0.6043,-1.6707 -2.16836,-2.84375 -4.0168,-2.84375s-3.4125,1.17305 -4.0168,2.84375l-9.84648,0l0,2.84375l9.84648,0c0.6043,1.6707 2.16836,2.84375 4.0168,2.84375zm-1.42187,-4.26562c0,-0.78203 0.63984,-1.42187 1.42187,-1.42187s1.42187,0.63984 1.42187,1.42187s-0.63984,1.42187 -1.42187,1.42187s-1.42187,-0.63984 -1.42187,-1.42187z"/>
+        <path id="svg_10" d="m16.97656,9.15625c1.84844,0 3.4125,-1.17305 4.0168,-2.84375l2.38164,0l0,-2.84375l-2.38164,0c-0.6043,-1.6707 -2.16836,-2.84375 -4.0168,-2.84375c-1.84844,0 -3.4125,1.17305 -4.0168,2.84375l-12.33477,0l0,2.84375l12.33477,0c0.6043,1.6707 2.16836,2.84375 4.0168,2.84375zm1.42187,-4.26562c0,0.78203 -0.63984,1.42187 -1.42187,1.42187s-1.42187,-0.63984 -1.42187,-1.42187s0.63984,-1.42187 1.42187,-1.42187s1.42187,0.63984 1.42187,1.42187z"/>
+      </g>
+
     </svg>
 
     <div id="content">
       <nav id="header" aria-label="Main Navigation">
         <button type='button' id="btn_login" class="large_button bordered">Login</button>
-        <!-- <button type='button' id="btn_config" class="large_button bordered">Config</button> -->
-        <button type='button' id="btn_about" class="large_button bordered">About</button>
+        <div class="nav_right">
+          <button type='button' id="btn_options" class="large_button bordered">Options</button>
+          <button type='button' id="btn_about" class="large_button bordered">About</button>
+        </div>
       </nav>
+
+
+      <div id="options_container" class="bordered">
+        <div>
+
+          <div class="check_option">
+            <label id="checkbox_replies_label" class="switch" for="checkbox_replies">
+              <input type="checkbox" id="checkbox_replies" class="options_checkbox" />
+              <span class="slider round"/>
+                <span class="switch_label">Include replies</span>
+            </label>
+          </div>
+
+          <div class="check_option">
+            <label id="checkbox_media_label" class="switch" for="checkbox_media">
+              <input type="checkbox" id="checkbox_media" class="options_checkbox" />
+              <span class="slider round"/>
+                <span class="switch_label">Only with media</span>
+            </label>
+          </div>
+
+          <div class="check_option">
+            <label id="checkbox_public_label" class="switch" for="checkbox_public">
+              <input type="checkbox" id="checkbox_public" class="options_checkbox" />
+              <span class="slider round"/>
+                <span class="switch_label">Only public toots.</span>
+            </label>
+          </div>
+
+        </div>
+        <button type='button' id="btn_apply_options" class="large_button bordered">Apply</button>
+      </div>
+
 
       <div id="tweet_list_wrap" class="bordered">
         <ul id="tweet_list" class="bordered">

--- a/public/js/login.js
+++ b/public/js/login.js
@@ -1,0 +1,101 @@
+import { getDataCookie, appendDataCookie, deleteDataCookie, setDataCookie } from './utils/Cookie.js';
+import MastodonApi from './utils/MastodonApi.js';
+import Logger from './utils/Logger.js';
+import { clearCodeTokenFromUrl } from './utils/Browser.js';
+import { showSnacError } from './ui/Snacbar.js';
+
+var log = new Logger()
+
+export function verifyLoginOrContinue() {
+  const loginData = getDataCookie();
+  if ('bearer_token' in loginData) {
+    return MastodonApi
+      .verifyCredentials(loginData.server, loginData.client_id, loginData.bearer_token)
+      .then(() => {
+        log.i("credentials valid")
+        document.getElementById("btn_login").textContent = "Logout"
+        Promise.resolve(true)
+      })
+      .catch((/** @type {Error} */ error) => {
+        log.w("Credentials appear invalid. Deleting persisted values.");
+        log.e(error);
+        deleteDataCookie();
+        showSnacError("Login error. Please try again.")
+        Promise.resolve(false)
+      })
+  } else {
+    return Promise.resolve(false)
+  }
+}
+
+
+/**
+ * @param {string} server
+ */
+export function performLogin(server) {
+  const data = { 'server': server }
+  setDataCookie(data) // overwrite old info
+
+  // there can be some weird whitespace characters in there for some reason
+  const callbackUrl = decodeURIComponent(window.location.href.toString())
+
+  MastodonApi.requestNewApiApp('justmytoots_test', server, callbackUrl)
+    .then(function(result) {
+      console.log(result)
+      const resultData = JSON.parse(result)
+      appendDataCookie({
+        client_id: resultData.client_id,
+        client_secret: resultData.client_secret,
+      })
+
+      clearCodeTokenFromUrl() // in case something whent really wrong last time remove leftovers
+
+      const loginData = getDataCookie()
+      MastodonApi.requestLoginPage(
+        loginData.server,
+        loginData.client_id,
+        callbackUrl
+      )
+    })
+}
+
+export async function handleLoginPartTwoOrContinue() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const currentCookieData = getDataCookie()
+
+  if (urlParams.has('code')
+    && 'client_id' in currentCookieData
+    && !('bearer_token' in currentCookieData)) {
+
+    log.i("Continuing login...")
+
+    // returned from login
+    appendDataCookie({ code: urlParams.get('code') })
+    clearCodeTokenFromUrl()
+
+    // there can be some weird whitespace characters in there for some reason
+    const callbackUrl = decodeURIComponent(window.location.href.toString())
+
+    try {
+      const loginData = getDataCookie()
+      const rawResultData = await MastodonApi.requestBearerToken(
+        loginData.server,
+        loginData.code,
+        loginData.client_id,
+        loginData.client_secret,
+        callbackUrl
+      );
+      const resultData = JSON.parse(rawResultData);
+
+      appendDataCookie({ bearer_token: resultData.access_token });
+
+      log.i("Login complete");
+    } catch (error) {
+      showSnacError("Error validating login. Please try again.");
+      log.e("Error during login. Deleting partial login data.", error);
+      deleteDataCookie();
+    }
+  } else {
+    return Promise.resolve()
+  }
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,403 +1,67 @@
-import { copyToClipboard } from './utils/System.js';
-import TootHtmlBuilder from './ui/TootHtmlBuilder.js';
-import { showSnacError, showSnacSuccess } from './ui/Snacbar.js';
 import { test_toots } from './testData.js';
 import { displayServerError, displayMissingUserMessage } from './ui/ErrorScreen.js';
 import Logger from './utils/Logger.js';
-import { showAboutModal, showImageModal, showLoginModal } from './ui/Modal.js';
-import { setDataCookie, getDataCookie, appendDataCookie, deleteDataCookie } from './utils/Cookie.js';
+import { getDataCookie } from './utils/Cookie.js';
 import MastodonApi from './utils/MastodonApi.js';
-import { addClickListenerForId, toggleHiddenElement, addUniqueClickListenerForEachOfClass } from './ui/Utils.js';
-import { clearCodeTokenFromUrl, getUserDataFromUrl } from './utils/Browser.js';
-
-var g_targetUserData = null
-var g_lastTootId = null
+import { getUrlParams, getUserDataFromUrl } from './utils/Browser.js';
+import { handleLoginPartTwoOrContinue, verifyLoginOrContinue } from './login.js';
+import { addInitialListeners, getTargetUserData, loadPageContent, loadToots, setTargetUserData, updateOptionsStates } from './ui/DomController.js';
 
 var log = new Logger()
 
-// NOTE:
+// NOTEs:
 // Disable pagespeed: url/?PageSpeed=off
 // https://stackoverflow.com/a/49243560/3968618
 // https://www.typescriptlang.org/docs/handbook/type-checking-javascript-files.html
+// https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html#types
 
 function main() {
-  const urlParams = new URLSearchParams(window.location.search);
-
   addInitialListeners()
+  updateOptionsStates()
   try {
-    g_targetUserData = getUserDataFromUrl()
+    setTargetUserData(getUserDataFromUrl())
   } catch (e) {
     displayMissingUserMessage(e)
     return
   }
 
-  if (urlParams.has('testdata')) {
+  if (getUrlParams().has('testdata')) {
     loadToots(test_toots)
     return
   }
 
   handleLoginPartTwoOrContinue()
     .then(() => {
-      const loginData = getDataCookie();
-      if ('bearer_token' in loginData) {
-        return MastodonApi
-          .verifyCredentials(loginData.server, loginData.client_id, loginData.bearer_token)
-          .then(() => {
-            log.i("credentials valid")
-            document.getElementById("btn_login").textContent = "Logout"
-            Promise.resolve(true)
-          })
-          .catch((/** @type {Error} */ error) => {
-            log.w("Credentials appear invalid. Deleting persisted values.");
-            log.e(error);
-            deleteDataCookie();
-            showSnacError("Login error. Please try again.")
-            Promise.resolve(false)
-          })
-      } else {
-        return Promise.resolve(false)
-      }
+      verifyLoginOrContinue()
     })
     .then(() => {
       const loginData = getDataCookie();
       if ('bearer_token' in loginData) {
         const loginData = getDataCookie();
         return MastodonApi
-          .getAccountInfo(loginData.server, g_targetUserData.handle, loginData.bearer_token)
+          .getAccountInfo(loginData.server, getTargetUserData().handle, loginData.bearer_token)
       } else {
         return MastodonApi
-          .getAccountInfo(g_targetUserData.server, g_targetUserData.handle)
+          .getAccountInfo(getTargetUserData().server, getTargetUserData().handle)
       }
     })
     .then((/** @type {object} */ result) => {
         const resultUserData = JSON.parse(result);
         log.t('resultUserData:', resultUserData);
         // merge the values we need into our data
-        g_targetUserData['id'] = resultUserData['id'];
-        g_targetUserData['avatar'] = resultUserData['avatar'];
-        g_targetUserData['display_name'] = resultUserData['display_name'];
-        g_targetUserData['url'] = resultUserData['url'];
-        log.d("Enriched target user data:", g_targetUserData);
+        const targetUserData = getTargetUserData()
+        targetUserData['id'] = resultUserData['id'];
+        targetUserData['avatar'] = resultUserData['avatar'];
+        targetUserData['display_name'] = resultUserData['display_name'];
+        targetUserData['url'] = resultUserData['url'];
+        log.d("Enriched target user data:", targetUserData);
+        setTargetUserData(targetUserData)
 
-        loadPageContent(g_targetUserData);
+        loadPageContent(targetUserData);
     })
     .catch((/** @type {Error} */ error) => {
       displayServerError(error)
     })
-}
-
-
-
-
-/**
- * @param {{ id: string; server: string; }} targetUserData
- * @param {string} [lastId]
- */
-function loadPageContent(targetUserData, lastId) {
-  if (!isLoading()) {
-    loaderOn()
-
-    Promise
-      .resolve(getDataCookie())
-      .then(loginData => {
-        if ('bearer_token' in loginData) {
-          return MastodonApi
-            .requestStatusses(loginData.server, targetUserData.id, lastId, loginData.bearer_token)
-        } else {
-          return MastodonApi
-            .requestStatusses(targetUserData.server, targetUserData.id, lastId)
-        }
-      })
-      .then(function(result) {
-        const resultToots = JSON.parse(result)
-        log.t("All toots returned:", resultToots)
-
-        if (resultToots.length > 0) {
-          g_lastTootId = resultToots[resultToots.length - 1]['id']
-        }
-
-        return resultToots
-          .filter((/** @type {{ [x: string]: any; }} */ toot) =>
-            !toot['reblog'] && !toot['in_reply_to_id'] && !toot['in_reply_to_account_id'])
-      })
-      .then(toots => {
-        loadToots(toots)
-      })
-  }
-}
-
-/**
- * @param {[{
- *    id: string;
- *    url: string;
- *    created_at?: string;
- *    sensitive?: boolean;
- *    spoiler_text: string;
- *    localized_toot_url?: string;
- *    account: { acct: string; }
- *    }]} toots
- */
-function loadToots(toots) {
-  log.d("Loading toots:", toots)
-
-  let loginData = getDataCookie()
-  toots.forEach((toot) => {
-    if (isLoggedIn()) {
-
-      // https://ohai.social/@cookie_mumbles/109512725350000401
-      // https://techhub.social/@cookie_mumbles@ohai.social/109512725627345234
-      // https://${server}/@${handle}/${toot.id}
-      toot['localized_profile_url'] = `https://${loginData.server}/${g_targetUserData.handle}`
-      toot['localized_toot_url'] = `https://${loginData.server}/${g_targetUserData.handle}/${toot.id}`
-    }
-    document.getElementById('tweet_list')
-      .appendChild(new TootHtmlBuilder().createTootDomItem(toot));
-  })
-
-  loaderOff()
-  addPostLoadListeners()
-  window.addEventListener("scroll", checkInfiniteScroll);
-}
-
-
-function addInitialListeners() {
-  addClickListenerForId("loginEvent", "btn_login", (/** @type MouseEvent */ event) => {
-    if (event.target.textContent == "Logout") {
-      deleteDataCookie()
-      document.getElementById("btn_login").textContent = "Login"
-    } else {
-      openLoginModal()
-    }
-  })
-
-  // addClickListenerForId("filtersEvent", "btn_config", () => {
-  //   // showFiltersModal()
-  // })
-  addClickListenerForId("aboutEvent", "btn_about", () => {
-    showAboutModal()
-  })
-}
-
-
-function addPostLoadListeners() {
-  addClickListenerForId("loadMoreEvent", 'down_arrow', function() {
-    loadPageContent(g_targetUserData, g_lastTootId)
-  })
-
-
-  addUniqueClickListenerForEachOfClass("copyEvent", "btn_action_copy", (/** @type MouseEvent */ event) => {
-    const prentDiv = event.target.closest('.single_tweet_wrap');
-    log.d("Clicked copy:" + prentDiv.dataset.tootUrl)
-    copyToClipboard(prentDiv.dataset.tootUrl)
-
-    showSnacSuccess("Copied toot url. Now paste it in your mastodon search.")
-  })
-
-  if (isLoggedIn()) {
-    Array.from(document.getElementsByClassName('toot_footer_btn'))
-      .forEach(element => {
-        element.disabled = false
-      })
-  }
-
-  addUniqueClickListenerForEachOfClass("boostClickEvent", "btn_action_boost", (/** @type MouseEvent */ event) => {
-    if (isLoggedIn()) {
-      const prentDiv = event.target.closest('.single_tweet_wrap');
-      const btn = event.target.closest('.toot_footer_btn')
-      const loginData = getDataCookie()
-      if (!btn.classList.contains('active')) {
-        MastodonApi.boost(
-          loginData.server,
-          loginData.bearer_token,
-          prentDiv.dataset.tootId
-        )
-          .then(_ => {
-            console.log("Successfully boosted.")
-          })
-        btn.classList.add("active")
-        btn.title = "Unboost"
-      } else {
-        MastodonApi.unboost(
-          loginData.server,
-          loginData.bearer_token,
-          prentDiv.dataset.tootId
-        )
-          .then(_ => {
-            console.log("Successfully unboosted.")
-          })
-        btn.classList.remove("active")
-        btn.title = "Boost"
-      }
-    } else {
-      showSnacError("Please log in or just copy the link.")
-    }
-  })
-
-
-  addUniqueClickListenerForEachOfClass("favoriteClickEvent", "btn_action_favorite", (/** @type MouseEvent */ event) => {
-    if (isLoggedIn()) {
-      const prentDiv = event.target.closest('.single_tweet_wrap');
-      const btn = event.target.closest('.toot_footer_btn')
-
-      const loginData = getDataCookie()
-      if (!btn.classList.contains('active')) {
-        MastodonApi
-          .favorite(
-            loginData.server,
-            loginData.bearer_token,
-            prentDiv.dataset.tootId
-          )
-          .then(_ => {
-            console.log("Successfully faved.")
-          })
-        btn.classList.add("active")
-        btn.title = "Unfavorite"
-      } else {
-        MastodonApi
-          .unfavorite(
-            loginData.server,
-            loginData.bearer_token,
-            prentDiv.dataset.tootId
-          )
-          .then(_ => {
-            console.log("Successfully unfaved.")
-          })
-        btn.classList.remove("active")
-        btn.title = "Favorite"
-      }
-    } else {
-      showSnacError("Please log in or just copy the link.")
-    }
-  })
-
-
-  addUniqueClickListenerForEachOfClass("contentWarningClickEvent", "content_warning", (/** @type MouseEvent */ event) => {
-    Array
-      .from(document.getElementsByClassName(`hidden_${event.target.dataset.tootId}`))
-      .forEach(hiddenElement => {
-        toggleHiddenElement(hiddenElement)
-      })
-  })
-
-  addUniqueClickListenerForEachOfClass("tootPicClickEvent", "toot_pic", (/** @type MouseEvent */ event) => {
-    /** @type HTMLImageElement  */
-    const img = event.target
-    showImageModal(img.src)
-  })
-}
-
-
-function checkInfiniteScroll() {
-  const endOfPage = window.innerHeight + window.pageYOffset >= document.body.offsetHeight;
-
-  if (endOfPage) {
-    loadPageContent(g_targetUserData, g_lastTootId)
-  }
-};
-
-function isLoading() {
-  return document.getElementById("down_arrow").style.display == 'none'
-}
-
-function loaderOff() {
-  document.getElementById("loader").style.display = "none";
-  document.getElementById("down_arrow").style.display = "inline-block";
-}
-
-function loaderOn() {
-  document.getElementById("loader").style.display = "block";
-  document.getElementById("down_arrow").style.display = "none";
-}
-
-function openLoginModal() {
-
-  showLoginModal()
-
-  document.getElementById("login_form_submit").onsubmit = function() {
-    /** @type {HTMLInputElement} */
-    // @ts-ignore
-    const inputElement = document.getElementById("input_server")
-    const value = inputElement.value.trim().toLowerCase()
-    performLogin(value)
-    return false // prevent default behavior
-  }
-}
-
-/**
- * @param {string} server
- */
-function performLogin(server) {
-  const data = { 'server': server }
-  setDataCookie(data) // overwrite old info
-
-  // there can be some weird whitespace characters in there for some reason
-  const callbackUrl = decodeURIComponent(window.location.href.toString())
-
-  MastodonApi.requestNewApiApp('justmytoots_test', server, callbackUrl)
-    .then(function(result) {
-      console.log(result)
-      const resultData = JSON.parse(result)
-      appendDataCookie({
-        client_id: resultData.client_id,
-        client_secret: resultData.client_secret,
-      })
-
-      clearCodeTokenFromUrl() // in case something whent really wrong last time remove leftovers
-
-      const loginData = getDataCookie()
-      MastodonApi.requestLoginPage(
-        loginData.server,
-        loginData.client_id,
-        callbackUrl
-      )
-    })
-}
-
-
-async function handleLoginPartTwoOrContinue() {
-  const urlParams = new URLSearchParams(window.location.search);
-  const currentCookieData = getDataCookie()
-
-  if (urlParams.has('code')
-    && 'client_id' in currentCookieData
-    && !('bearer_token' in currentCookieData)) {
-
-    log.i("Continuing login...")
-
-    // returned from login
-    appendDataCookie({ code: urlParams.get('code') })
-    clearCodeTokenFromUrl()
-
-    // there can be some weird whitespace characters in there for some reason
-    const callbackUrl = decodeURIComponent(window.location.href.toString())
-
-    try {
-      const loginData = getDataCookie()
-      const rawResultData = await MastodonApi.requestBearerToken(
-        loginData.server,
-        loginData.code,
-        loginData.client_id,
-        loginData.client_secret,
-        callbackUrl
-      );
-      const resultData = JSON.parse(rawResultData);
-
-      appendDataCookie({ bearer_token: resultData.access_token });
-
-      log.i("Login complete");
-    } catch (error) {
-      showSnacError("Error validating login. Please try again.");
-      log.e("Error during login. Deleting partial login data.", error);
-      deleteDataCookie();
-    }
-  } else {
-    return Promise.resolve()
-  }
-}
-
-function isLoggedIn() {
-  const currentCookieData = getDataCookie()
-  return 'bearer_token' in currentCookieData
 }
 
 

--- a/public/js/testData.js
+++ b/public/js/testData.js
@@ -1,3 +1,62 @@
+/**
+ * @typedef {Object} AccountJson
+ * @prop {string} id
+ * @prop {string} username
+ * @prop {string} acct
+ * @prop {string} display_name
+ * @prop {boolean} locked
+ * @prop {boolean} bot
+ * @prop {boolean} discoverable
+ * @prop {boolean} group
+ * @prop {string} created_at
+ * @prop {string} note
+ * @prop {string} url
+ * @prop {string} avatar
+ * @prop {string} avatar_static
+ * @prop {string} header
+ * @prop {string} header_static
+ * @prop {number} followers_count
+ * @prop {number} following_count
+ * @prop {number} statuses_count
+ * @prop {string} last_status_at
+ * @prop {boolean} noindex
+ * @prop {any[]} emojis
+ * @prop {string} [role]
+ * @prop {any[]} fields
+ */
+
+
+/**
+ * @typedef {Object} TootJson
+ * @prop {string} id
+ * @prop {string} created_at
+ * @prop {string} in_reply_to_id
+ * @prop {string} in_reply_to_account_id
+ * @prop {boolean} sensitive
+ * @prop {string} spoiler_text
+ * @prop {string} visibility
+ * @prop {string} language
+ * @prop {string} uri
+ * @prop {string} url
+ * @prop {number} replies_count
+ * @prop {number} reblogs_count
+ * @prop {number} favourites_count
+ * @prop {string} edited_at
+ * @prop {string} content
+ * @prop {any} reblog
+ * @prop {any} application
+ * @prop {string} created_at
+ * @prop {string} [localized_toot_url]
+ * @prop {AccountJson} account
+ * @prop {any[]} media_attachments
+ * @prop {any[]} mentions
+ * @prop {any[]} tags
+ * @prop {any[]} emojis
+ * @prop {any} card
+ * @prop {any} poll
+ */
+
+/** @type {TootJson[]} */
 export const test_toots = [
   {
     "id": "109472499431799134",
@@ -29,7 +88,7 @@ export const test_toots = [
       "created_at": "2022-11-21T00:00:00.000Z",
       "note": "<p>Friendly cis cookie on a quest to make you chuckle</p><p>My toots -&gt; <a href=\"https://justmytoots.com/cookie_mumbles@ohai.social\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"ellipsis\">justmytoots.com/cookie_mumbles</span><span class=\"invisible\">@ohai.social</span></a></p><p>best-of etc on twitter -&gt; <a href=\"https://linktr.ee/cookie_mumbles\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">linktr.ee/cookie_mumbles</span><span class=\"invisible\"></span></a></p><p><a href=\"https://ohai.social/tags/fedi22\" class=\"mention hashtag\" rel=\"tag\">#<span>fedi22</span></a><br /><a href=\"https://ohai.social/tags/jokes\" class=\"mention hashtag\" rel=\"tag\">#<span>jokes</span></a> <a href=\"https://ohai.social/tags/fun\" class=\"mention hashtag\" rel=\"tag\">#<span>fun</span></a> <a href=\"https://ohai.social/tags/nobot\" class=\"mention hashtag\" rel=\"tag\">#<span>nobot</span></a> <a href=\"https://ohai.social/tags/joke\" class=\"mention hashtag\" rel=\"tag\">#<span>joke</span></a> <a href=\"https://ohai.social/tags/humor\" class=\"mention hashtag\" rel=\"tag\">#<span>humor</span></a> <a href=\"https://ohai.social/tags/trending\" class=\"mention hashtag\" rel=\"tag\">#<span>trending</span></a> <a href=\"https://ohai.social/tags/funny\" class=\"mention hashtag\" rel=\"tag\">#<span>funny</span></a></p>",
       "url": "https://ohai.social/@cookie_mumbles",
-      "avatar": "https://files.ohai.social/accounts/avatars/109/380/999/955/395/974/original/c814d08a32d2a639.png",
+      "avatar": "https://files.ohai.social/accounts/avatars/109/380/999/955/395/974/original/fcf1fa4565af0718.png",
       "avatar_static": "https://files.ohai.social/accounts/avatars/109/380/999/955/395/974/original/c814d08a32d2a639.png",
       "header": "https://files.ohai.social/accounts/headers/109/380/999/955/395/974/original/9c502235dd1c0795.jpeg",
       "header_static": "https://files.ohai.social/accounts/headers/109/380/999/955/395/974/original/9c502235dd1c0795.jpeg",
@@ -48,8 +107,147 @@ export const test_toots = [
     "emojis": [],
     "card": null,
     "poll": null
-  },
-  {
+  }, {
+    "id": "109683800922113496",
+    "created_at": "2023-01-13T20:33:01.842Z",
+    "in_reply_to_id": "109683797485314862",
+    "in_reply_to_account_id": "109466064772943163",
+    "sensitive": false,
+    "spoiler_text": "",
+    "visibility": "unlisted",
+    "language": "en",
+    "uri": "https://techhub.social/users/cookie_mumbles/statuses/109683800922113496",
+    "url": "https://techhub.social/@cookie_mumbles/109683800922113496",
+    "replies_count": 0,
+    "reblogs_count": 0,
+    "favourites_count": 0,
+    "edited_at": null,
+    "favourited": false,
+    "reblogged": false,
+    "muted": false,
+    "bookmarked": false,
+    "pinned": false,
+    "content": "<p>Looks good. How about replies?</p>",
+    "filtered": [],
+    "reblog": null,
+    "application": {
+      "name": "Web",
+      "website": null
+    },
+    "account": {
+      "id": "109466064772943163",
+      "username": "cookie_mumbles",
+      "acct": "cookie_mumbles",
+      "display_name": "Cookie Codes",
+      "locked": false,
+      "bot": false,
+      "discoverable": true,
+      "group": false,
+      "created_at": "2022-12-06T00:00:00.000Z",
+      "note": "<p>Software developer that makes jokes over at <span class=\"h-card\"><a href=\"https://ohai.social/@cookie_mumbles\" class=\"u-url mention\">@<span>cookie_mumbles</span></a></span> and jokes and chats about software and other stuff here.</p><p>  Creater of <a href=\"https://justmytoots.com\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">justmytoots.com</span><span class=\"invisible\"></span></a>   </p><p>Github: <a href=\"https://github.com/cookiemumbles\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">github.com/cookiemumbles</span><span class=\"invisible\"></span></a></p>",
+      "url": "https://techhub.social/@cookie_mumbles",
+      "avatar": "https://files.techhub.social/accounts/avatars/109/466/064/772/943/163/original/be9f6fc721dd03a8.png",
+      "avatar_static": "https://files.techhub.social/accounts/avatars/109/466/064/772/943/163/original/be9f6fc721dd03a8.png",
+      "header": "https://files.techhub.social/accounts/headers/109/466/064/772/943/163/original/a5372985ca1dd032.jpeg",
+      "header_static": "https://files.techhub.social/accounts/headers/109/466/064/772/943/163/original/a5372985ca1dd032.jpeg",
+      "followers_count": 26,
+      "following_count": 71,
+      "statuses_count": 125,
+      "last_status_at": "2023-01-13",
+      "noindex": false,
+      "emojis": [],
+      "fields": [
+        {
+          "name": "Main account",
+          "value": "<a href=\"https://ohai.social/@cookie_mumbles\" target=\"_blank\" rel=\"nofollow noopener noreferrer me\"><span class=\"invisible\">https://</span><span class=\"\">ohai.social/@cookie_mumbles</span><span class=\"invisible\"></span></a>",
+          "verified_at": null
+        },
+        {
+          "name": "My Toots",
+          "value": "<a href=\"https://justmytoots.com/@cookie_mumbles@techhub.social\" target=\"_blank\" rel=\"nofollow noopener noreferrer me\"><span class=\"invisible\">https://</span><span class=\"ellipsis\">justmytoots.com/@cookie_mumble</span><span class=\"invisible\">s@techhub.social</span></a>",
+          "verified_at": null
+        }
+      ]
+    },
+    "media_attachments": [],
+    "mentions": [],
+    "tags": [],
+    "emojis": [],
+    "card": null,
+    "poll": null,
+    "localized_profile_url": "https://techhub.social/@cookie_mumbles@techhub.social",
+    "localized_toot_url": "https://techhub.social/@cookie_mumbles@techhub.social/109683800922113496"
+  },{
+    "id": "109683797485314862",
+    "created_at": "2023-01-13T20:32:09.405Z",
+    "in_reply_to_id": null,
+    "in_reply_to_account_id": null,
+    "sensitive": false,
+    "spoiler_text": "",
+    "visibility": "unlisted",
+    "language": "en",
+    "uri": "https://techhub.social/users/cookie_mumbles/statuses/109683797485314862",
+    "url": "https://techhub.social/@cookie_mumbles/109683797485314862",
+    "replies_count": 1,
+    "reblogs_count": 0,
+    "favourites_count": 0,
+    "edited_at": null,
+    "favourited": false,
+    "reblogged": false,
+    "muted": false,
+    "bookmarked": false,
+    "pinned": false,
+    "content": "<p>Let&#39;s see if we can filter out &#39;unlisted&#39; toots.</p>",
+    "filtered": [],
+    "reblog": null,
+    "application": {
+      "name": "Web",
+      "website": null
+    },
+    "account": {
+      "id": "109466064772943163",
+      "username": "cookie_mumbles",
+      "acct": "cookie_mumbles",
+      "display_name": "Cookie Codes",
+      "locked": false,
+      "bot": false,
+      "discoverable": true,
+      "group": false,
+      "created_at": "2022-12-06T00:00:00.000Z",
+      "note": "",
+      "url": "https://techhub.social/@cookie_mumbles",
+      "avatar": "https://files.techhub.social/accounts/avatars/109/466/064/772/943/163/original/be9f6fc721dd03a8.png",
+      "avatar_static": "https://files.techhub.social/accounts/avatars/109/466/064/772/943/163/original/be9f6fc721dd03a8.png",
+      "header": "https://files.techhub.social/accounts/headers/109/466/064/772/943/163/original/a5372985ca1dd032.jpeg",
+      "header_static": "https://files.techhub.social/accounts/headers/109/466/064/772/943/163/original/a5372985ca1dd032.jpeg",
+      "followers_count": 26,
+      "following_count": 71,
+      "statuses_count": 125,
+      "last_status_at": "2023-01-13",
+      "noindex": false,
+      "emojis": [],
+      "fields": [
+        {
+          "name": "Main account",
+          "value": "<a href=\"https://ohai.social/@cookie_mumbles\" target=\"_blank\" rel=\"nofollow noopener noreferrer me\"><span class=\"invisible\">https://</span><span class=\"\">ohai.social/@cookie_mumbles</span><span class=\"invisible\"></span></a>",
+          "verified_at": null
+        },
+        {
+          "name": "My Toots",
+          "value": "<a href=\"https://justmytoots.com/@cookie_mumbles@techhub.social\" target=\"_blank\" rel=\"nofollow noopener noreferrer me\"><span class=\"invisible\">https://</span><span class=\"ellipsis\">justmytoots.com/@cookie_mumble</span><span class=\"invisible\">s@techhub.social</span></a>",
+          "verified_at": null
+        }
+      ]
+    },
+    "media_attachments": [],
+    "mentions": [],
+    "tags": [],
+    "emojis": [],
+    "card": null,
+    "poll": null,
+    "localized_profile_url": "https://techhub.social/@cookie_mumbles@techhub.social",
+    "localized_toot_url": "https://techhub.social/@cookie_mumbles@techhub.social/109683797485314862"
+  },{
     "id": "109463245078881912",
     "created_at": "2022-12-05T21:42:46.756Z",
     "in_reply_to_id": null,
@@ -82,7 +280,7 @@ export const test_toots = [
       "created_at": "2022-11-21T00:00:00.000Z",
       "note": "<p>Friendly cis cookie on a quest to make you chuckle</p><p>My toots -&gt; <a href=\"https://justmytoots.com/cookie_mumbles@ohai.social\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"ellipsis\">justmytoots.com/cookie_mumbles</span><span class=\"invisible\">@ohai.social</span></a></p><p>best-of etc on twitter -&gt; <a href=\"https://linktr.ee/cookie_mumbles\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">https://</span><span class=\"\">linktr.ee/cookie_mumbles</span><span class=\"invisible\"></span></a></p><p><a href=\"https://ohai.social/tags/fedi22\" class=\"mention hashtag\" rel=\"tag\">#<span>fedi22</span></a><br /><a href=\"https://ohai.social/tags/jokes\" class=\"mention hashtag\" rel=\"tag\">#<span>jokes</span></a> <a href=\"https://ohai.social/tags/fun\" class=\"mention hashtag\" rel=\"tag\">#<span>fun</span></a> <a href=\"https://ohai.social/tags/nobot\" class=\"mention hashtag\" rel=\"tag\">#<span>nobot</span></a> <a href=\"https://ohai.social/tags/joke\" class=\"mention hashtag\" rel=\"tag\">#<span>joke</span></a> <a href=\"https://ohai.social/tags/humor\" class=\"mention hashtag\" rel=\"tag\">#<span>humor</span></a> <a href=\"https://ohai.social/tags/trending\" class=\"mention hashtag\" rel=\"tag\">#<span>trending</span></a> <a href=\"https://ohai.social/tags/funny\" class=\"mention hashtag\" rel=\"tag\">#<span>funny</span></a></p>",
       "url": "https://ohai.social/@cookie_mumbles",
-      "avatar": "https://files.ohai.social/accounts/avatars/109/380/999/955/395/974/original/c814d08a32d2a639.png",
+      "avatar": "https://files.ohai.social/accounts/avatars/109/380/999/955/395/974/original/fcf1fa4565af0718.png",
       "avatar_static": "https://files.ohai.social/accounts/avatars/109/380/999/955/395/974/original/c814d08a32d2a639.png",
       "header": "https://files.ohai.social/accounts/headers/109/380/999/955/395/974/original/9c502235dd1c0795.jpeg",
       "header_static": "https://files.ohai.social/accounts/headers/109/380/999/955/395/974/original/9c502235dd1c0795.jpeg",
@@ -135,7 +333,7 @@ export const test_toots = [
       "created_at": "2022-11-15T00:00:00.000Z",
       "note": "<p>🏳️‍🌈 He / Him 😋 Twitter refugee 💥 If you want my professional opinion, you’re crazy 👉 More random stuff: <a href=\"http://www.justmytoots.com/professorkiosk@beige.party\" target=\"_blank\" rel=\"nofollow noopener noreferrer\"><span class=\"invisible\">http://www.</span><span class=\"ellipsis\">justmytoots.com/professorkiosk</span><span class=\"invisible\">@beige.party</span></a></p>",
       "url": "https://beige.party/@professorkiosk",
-      "avatar": "https://media.beige.party/accounts/avatars/109/348/062/348/732/026/original/d95af2bf43ad2337.png",
+      "avatar": "https://files.ohai.social/cache/accounts/avatars/109/348/338/288/355/816/original/5f99304e9d0a1fe3.png",
       "avatar_static": "https://media.beige.party/accounts/avatars/109/348/062/348/732/026/original/d95af2bf43ad2337.png",
       "header": "https://media.beige.party/accounts/headers/109/348/062/348/732/026/original/7922b66ee77780b8.jpeg",
       "header_static": "https://media.beige.party/accounts/headers/109/348/062/348/732/026/original/7922b66ee77780b8.jpeg",

--- a/public/js/ui/DomController.js
+++ b/public/js/ui/DomController.js
@@ -1,0 +1,331 @@
+import { addUrlSearchParam, getUrlParams, removeUrlSearchParam } from "../utils/Browser.js"
+import { deleteDataCookie, getDataCookie } from "../utils/Cookie.js"
+import Logger from "../utils/Logger.js"
+import MastodonApi from "../utils/MastodonApi.js"
+import { copyToClipboard } from "../utils/System.js"
+import { showAboutModal, showImageModal, showLoginModal } from "./Modal.js"
+import { showSnacError, showSnacSuccess } from "./Snacbar.js"
+import TootHtmlBuilder from "./TootHtmlBuilder.js"
+import { addUniqueClickListenerForId, addUniqueClickListenerForEachOfClass, addUniqueEventListener, addUniqueListenerForEachOfClass, toggleHiddenElement } from "./Utils.js"
+
+
+/**
+ * @typedef {Object} UserData
+ * @prop {string} server
+ * @prop {string} userName
+ * @prop {string} handle
+ * @prop {string} [id]
+ * @prop {string} [avatar]
+ * @prop {string} [display_name]
+ * @prop {string} [url]
+ */
+
+/** @typedef { import("../testData.js").TootJson } TootJson */
+
+/** @type {UserData} */
+var g_targetUserData = null
+
+/** @type string */
+var g_lastTootId = null
+
+var log = new Logger()
+
+
+export function addInitialListeners() {
+  addUniqueClickListenerForId("loginEvent", "btn_login", (/** @type MouseEvent */ event) => {
+    const target = /** @type HTMLButtonElement */ (event.target)
+    if (target.textContent == "Logout") {
+      deleteDataCookie()
+      document.getElementById("btn_login").textContent = "Login"
+    } else {
+      showLoginModal()
+    }
+  })
+
+  addUniqueClickListenerForId("toggleOptionsEvent", "btn_options", (/** @type MouseEvent */ event) => {
+    /** @type HTMLElement */
+    const optionsContainer = document.getElementById("options_container")
+    if (optionsContainer.classList.contains("show")) {
+      optionsContainer.classList.remove("show")
+    } else {
+      optionsContainer.classList.add("show")
+    }
+  })
+
+  addUniqueClickListenerForId("aboutEvent", "btn_about", () => {
+    showAboutModal()
+  })
+
+  addUniqueClickListenerForId('applyOptions', 'btn_apply_options', () => {
+    location.reload()
+  })
+
+  addUniqueListenerForEachOfClass('toggleOptionsCheck', 'options_checkbox', 'change', (event) => {
+    const target = /** @type HTMLInputElement */ (event.target)
+    let param = checkboxIdToParamName(target.id)
+    if (target.checked) {
+      addUrlSearchParam(param, "true")
+    } else {
+      removeUrlSearchParam(param)
+    }
+  })
+}
+
+export function updateOptionsStates() {
+  Array
+    .from(document.getElementsByClassName('options_checkbox'))
+    .forEach((/** @type HTMLInputElement */ checkbox) => {
+      checkbox.checked = getUrlParams().get(checkboxIdToParamName(checkbox.id)) == 'true'
+    })
+}
+
+const OPT_REPLIES = 'replies'
+const OPT_MEDIA_ONLY = 'media_only'
+const OPT_PUBLIC_ONLY = 'public_only'
+
+/** @param {string} id */
+function checkboxIdToParamName(id) {
+  switch (id) {
+    case 'checkbox_replies':
+      return OPT_REPLIES
+    case 'checkbox_media':
+      return OPT_MEDIA_ONLY
+    case 'checkbox_public':
+      return OPT_PUBLIC_ONLY
+  }
+}
+
+/**
+ * @param {UserData} targetUserData
+ * @param {string} [lastId]
+ */
+export function loadPageContent(targetUserData, lastId) {
+  if (!isLoading()) {
+    loaderOn()
+
+    Promise
+      .resolve(getDataCookie())
+      .then(loginData => {
+        if ('bearer_token' in loginData) {
+          return MastodonApi
+            .requestStatusses(loginData.server, targetUserData.id, lastId, loginData.bearer_token)
+        } else {
+          return MastodonApi
+            .requestStatusses(targetUserData.server, targetUserData.id, lastId)
+        }
+      })
+      .then(function(result) {
+        /** @type {TootJson[]} */
+        const resultToots = JSON.parse(result)
+
+        if (resultToots.length > 0) {
+          setLastTootId(resultToots[resultToots.length - 1]['id'])
+        }
+
+        loadToots(resultToots)
+      })
+  }
+}
+
+/** @param {TootJson[]} toots */
+export function loadToots(toots) {
+  log.d("Loading toots:", toots)
+
+  let loginData = getDataCookie()
+  toots
+    .filter(toot =>  !toot['reblog'] )
+    .filter(toot => 
+      getUrlParams().get(OPT_REPLIES) == 'true'
+      || (!toot['in_reply_to_id'] && !toot['in_reply_to_account_id'])
+    )
+    .filter(toot => 
+      getUrlParams().get(OPT_PUBLIC_ONLY) != 'true'
+      || toot['visibility'] == 'public' 
+    )
+    .filter(toot => 
+      getUrlParams().get(OPT_MEDIA_ONLY) != 'true'
+      || toot['media_attachments'].length > 0
+    )
+    .forEach((toot) => {
+    if (isLoggedIn()) {
+
+      // https://ohai.social/@cookie_mumbles/109512725350000401
+      // https://techhub.social/@cookie_mumbles@ohai.social/109512725627345234
+      // https://${server}/@${handle}/${toot.id}
+      toot['localized_profile_url'] = `https://${loginData.server}/${getTargetUserData().handle}`
+      toot['localized_toot_url'] = `https://${loginData.server}/${getTargetUserData().handle}/${toot.id}`
+    }
+    document.getElementById('tweet_list')
+      .appendChild(new TootHtmlBuilder().createTootDomItem(toot));
+  })
+
+  loaderOff()
+  addPostLoadListeners()
+  window.addEventListener("scroll", checkInfiniteScroll);
+}
+
+
+function addPostLoadListeners() {
+  addUniqueClickListenerForId("loadMoreEvent", 'down_arrow', function() {
+    loadPageContent(getTargetUserData(), getLastTootId())
+  })
+
+
+  addUniqueClickListenerForEachOfClass("copyEvent", "btn_action_copy", (/** @type MouseEvent */ event) => {
+    const target = /** @type HTMLButtonElement */ (event.target)
+    const prentDiv = /** @type HTMLElement */ (target.closest('.single_tweet_wrap'))
+    log.d("Clicked copy:" + prentDiv.dataset.tootUrl)
+    copyToClipboard(prentDiv.dataset.tootUrl)
+
+    showSnacSuccess("Copied toot url. Now paste it in your mastodon search.")
+  })
+
+  if (isLoggedIn()) {
+    Array.from(document.getElementsByClassName('toot_footer_btn'))
+      .forEach((/** @type HTMLElement */ element) => {
+        element["disabled"] = false
+      })
+  }
+
+  addUniqueClickListenerForEachOfClass("boostClickEvent", "btn_action_boost", (/** @type MouseEvent */ event) => {
+    if (isLoggedIn()) {
+      const target = /** @type HTMLButtonElement */ (event.target)
+      const prentDiv = /** @type HTMLElement */ (target.closest('.single_tweet_wrap'))
+      const btn = target.closest('.toot_footer_btn')
+      const loginData = getDataCookie()
+      if (!btn.classList.contains('active')) {
+        MastodonApi
+          .boost(
+            loginData.server,
+            loginData.bearer_token,
+            prentDiv.dataset.tootId
+          )
+          .then(_ => {
+            console.log("Successfully boosted.")
+          })
+        btn.classList.add("active")
+        btn['title'] = "Unboost"
+      } else {
+        MastodonApi
+          .unboost(
+            loginData.server,
+            loginData.bearer_token,
+            prentDiv.dataset.tootId
+          )
+          .then(_ => {
+            console.log("Successfully unboosted.")
+          })
+        btn.classList.remove("active")
+        btn['title'] = "Boost"
+      }
+    } else {
+      showSnacError("Please log in or just copy the link.")
+    }
+  })
+
+
+  addUniqueClickListenerForEachOfClass("favoriteClickEvent", "btn_action_favorite", (/** @type MouseEvent */ event) => {
+    if (isLoggedIn()) {
+      const target = /** @type HTMLButtonElement */ (event.target)
+      const prentDiv = /** @type HTMLElement */ (target.closest('.single_tweet_wrap'))
+      const btn = /** @type HTMLButtonElement */ (target.closest('.toot_footer_btn'))
+
+      const loginData = getDataCookie()
+      if (!btn.classList.contains('active')) {
+        MastodonApi
+          .favorite(
+            loginData.server,
+            loginData.bearer_token,
+            prentDiv.dataset.tootId
+          )
+          .then(_ => {
+            console.log("Successfully faved.")
+          })
+        btn.classList.add("active")
+        btn.title = "Unfavorite"
+      } else {
+        MastodonApi
+          .unfavorite(
+            loginData.server,
+            loginData.bearer_token,
+            prentDiv.dataset.tootId
+          )
+          .then(_ => {
+            console.log("Successfully unfaved.")
+          })
+        btn.classList.remove("active")
+        btn.title = "Favorite"
+      }
+    } else {
+      showSnacError("Please log in or just copy the link.")
+    }
+  })
+
+
+  addUniqueClickListenerForEachOfClass("contentWarningClickEvent", "content_warning", (/** @type MouseEvent */ event) => {
+    const target = /** @type HTMLButtonElement */ (event.target)
+    Array
+      .from(document.getElementsByClassName(`hidden_${target.dataset.tootId}`))
+      .forEach(hiddenElement => {
+        toggleHiddenElement(/** @type HTMLButtonElement */ (hiddenElement))
+      })
+  })
+
+  addUniqueClickListenerForEachOfClass("tootPicClickEvent", "toot_pic", (/** @type MouseEvent */ event) => {
+    const img = /** @type HTMLImageElement  */ (event.target)
+    showImageModal(img.src)
+  })
+}
+
+export function checkInfiniteScroll() {
+  const endOfPage = window.innerHeight + window.pageYOffset >= document.body.offsetHeight;
+
+  if (endOfPage) {
+    loadPageContent(getTargetUserData(), getLastTootId())
+  }
+};
+
+
+export function isLoading() {
+  return document.getElementById("down_arrow").style.display == 'none'
+}
+
+export function isLoggedIn() {
+  const currentCookieData = getDataCookie()
+  return 'bearer_token' in currentCookieData
+}
+
+export function loaderOn() {
+  document.getElementById("loader").style.display = "block";
+  document.getElementById("down_arrow").style.display = "none";
+}
+
+
+export function loaderOff() {
+  document.getElementById("loader").style.display = "none";
+  document.getElementById("down_arrow").style.display = "inline-block";
+}
+
+
+
+
+
+/** @param {UserData} targetUserData */
+export function setTargetUserData(targetUserData) {
+  g_targetUserData = targetUserData
+}
+
+/** @returns {UserData} */
+export function getTargetUserData() {
+  return g_targetUserData
+}
+
+/** @param {string} lastTootId */
+export function setLastTootId(lastTootId) {
+  g_lastTootId = lastTootId
+}
+
+/** @returns string */
+export function getLastTootId() {
+  return g_lastTootId
+}

--- a/public/js/ui/Modal.js
+++ b/public/js/ui/Modal.js
@@ -1,3 +1,4 @@
+import { performLogin } from '../login.js';
 import { wrapIn, createElement } from './HtmlBuilder.js';
 
 export function showModal() {
@@ -53,6 +54,16 @@ export function showLoginModal() {
       createElement('button', {id: "btn_action_login"}, "submit")
     ])
   )
+
+
+  document.getElementById("login_form_submit").onsubmit = function() {
+    /** @type {HTMLInputElement} */
+    // @ts-ignore
+    const inputElement = document.getElementById("input_server")
+    const value = inputElement.value.trim().toLowerCase()
+    performLogin(value)
+    return false // prevent default behavior
+  }
 }
 
 export function showAboutModal() {

--- a/public/js/ui/Utils.js
+++ b/public/js/ui/Utils.js
@@ -7,7 +7,7 @@
 export function addUniqueClickListenerForEachOfClass(listenerId, classname, eventListener) {
     Array
         .from(document.getElementsByClassName(classname))
-        .forEach(currentElement => {
+        .forEach((/** @type HTMLElement */ currentElement) => {
             addUniqueEventListener(currentElement, listenerId, 'click', eventListener)
         })
 }
@@ -17,7 +17,7 @@ export function addUniqueClickListenerForEachOfClass(listenerId, classname, even
  * @param {{(event: MouseEvent): void;(): void;(): void;(this: HTMLElement, ev: MouseEvent): any;}} eventListener
  * @param {string} listenerId
  */
-export function addClickListenerForId(listenerId, id, eventListener) {
+export function addUniqueClickListenerForId(listenerId, id, eventListener) {
     addUniqueEventListener(document.getElementById(id), listenerId, 'click', eventListener)
 }
 
@@ -37,8 +37,22 @@ export function toggleHiddenElement(hiddenElement) {
 }
 
 /**
+ * @param {string} listenerId
+ * @param {string} classname
+ * @param {string} eventType
+ * @param {EventListenerOrEventListenerObject} eventListener
+ */
+export function addUniqueListenerForEachOfClass(listenerId, classname, eventType, eventListener) {
+    Array
+        .from(document.getElementsByClassName(classname))
+        .forEach(currentElement => {
+            addUniqueEventListener(currentElement, listenerId, eventType, eventListener)
+        })
+}
+
+/**
  * Adds an event listener, but does not re-add a listener with the same id
- * @param {Element} targetElement
+ * @param {HTMLElement} targetElement
  * @param {string} listenerId
  * @param {string} eventType
  * @param {EventListenerOrEventListenerObject} eventListener
@@ -49,7 +63,7 @@ export function addUniqueEventListener(targetElement, listenerId, eventType, eve
         listenerList = targetElement.dataset.listeners.split(" ")
     }
     if (!listenerList.includes(listenerId)) {
-        targetElement.addEventListener('click', eventListener);
+        targetElement.addEventListener(eventType, eventListener);
         listenerList.push(listenerId)
         targetElement.dataset.listeners = listenerList.join(" ")
     }

--- a/public/js/utils/Browser.js
+++ b/public/js/utils/Browser.js
@@ -24,7 +24,7 @@ export function getUserDataFromUrl() {
 
 
 export function getUserHandle() {
-  const urlParams = new URLSearchParams(window.location.search);
+  const urlParams = getUrlParams()
   if (window.location.pathname != "/") {
     return window.location.pathname.slice(1)
   } else if (urlParams.has('acct')) {
@@ -35,10 +35,30 @@ export function getUserHandle() {
 }
 
 export function clearCodeTokenFromUrl() {
-  const urlParams = new URLSearchParams(window.location.search);
-  while (urlParams.has('code')) { // in case old ones
-    urlParams.delete('code')
+  removeUrlSearchParam('code')
+}
+
+/** @param {string} paramName */
+export function removeUrlSearchParam(paramName) {
+  const urlParams = getUrlParams()
+  while (urlParams.has(paramName)) { // in case old ones
+    urlParams.delete(paramName)
   }
   const newUrl = buildUrl(window.location.href, urlParams)
   window.history.replaceState({}, "", newUrl);
+}
+
+/**
+ * @param {string} name
+ * @param {string} value
+ */
+export function addUrlSearchParam(name, value) {
+  const urlParams = getUrlParams()
+  urlParams.set(name, value)
+  const newUrl = buildUrl(window.location.href, urlParams)
+  window.history.replaceState({}, "", newUrl);
+}
+
+export function getUrlParams() {
+  return new URLSearchParams(window.location.search);
 }

--- a/selenium-test/build.gradle.kts
+++ b/selenium-test/build.gradle.kts
@@ -21,4 +21,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.21.0")
 }
 
-tasks.withType<Test> { useJUnitPlatform() }
+tasks.withType<Test> {
+    useJUnitPlatform()
+    testLogging.showStandardStreams = true
+}

--- a/selenium-test/src/test/kotlin/com/justmytoots/utils/DomainFinders.kt
+++ b/selenium-test/src/test/kotlin/com/justmytoots/utils/DomainFinders.kt
@@ -5,13 +5,38 @@ import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.WebElement
 
-fun WebDriver.findSnacbar() = findElement(By.id("snackbar"))
+// nav
 
-fun WebElement.getSnacText() = findElement(By.className("tweet_header"))
+fun WebDriver.findLoginBtn() = findElement(By.id("btn_login"))
+
+fun WebDriver.findOptionsBtn() = findElement(By.id("btn_options"))
+
+fun WebDriver.findAboutBtn() = findElement(By.id("btn_about"))
+
+// options
+
+fun WebDriver.findOptionsContainer() = findElement(By.id("options_container"))
+
+fun WebDriver.findOptionLabelReplies() = findElement(By.id("checkbox_replies_label"))
+
+fun WebDriver.findOptionCheckReplies() = findElement(By.id("checkbox_replies"))
+
+fun WebDriver.findOptionLabelMedia() = findElement(By.id("checkbox_media_label"))
+
+fun WebDriver.findOptionCheckMedia() = findElement(By.id("checkbox_media"))
+
+// toots
 
 fun WebDriver.findToots() =
     waitForElement(By.id("tweet_list"), Duration.ofSeconds(3))
         .waitForAllElements(By.tagName("li"), Duration.ofSeconds(5)) // sometimes very slow
+
+fun List<WebElement>.mapToTootIds() =
+    map { it.findElement(By.cssSelector("*")) }.map { it.getAttribute("data-toot-id") }
+
+fun WebDriver.waitForPageLoaded() {
+    findToots()
+}
 
 fun WebDriver.findFirstToot() = findToots().first()
 
@@ -25,17 +50,19 @@ fun WebElement.getFaveBtn() = findElement(By.className("btn_action_favorite"))
 
 fun WebElement.getCopyBtn() = findElement(By.className("btn_action_copy"))
 
-fun WebDriver.findLoginBtn() = findElement(By.id("btn_login"))
+// snacbar
 
-fun WebDriver.findAboutBtn() = findElement(By.id("btn_about"))
+fun WebDriver.findSnacbar() = findElement(By.id("snackbar"))
+
+fun WebElement.getSnacText() = findElement(By.className("tweet_header"))
+
+// modal
 
 fun WebDriver.findModalBackground() = findElement(By.id("modal_background"))
 
 fun WebDriver.findModalClose() = findElement(By.id("model_close"))
 
-fun WebDriver.waitForPageLoaded() {
-    findToots()
-}
+// error page
 
 fun WebDriver.findPageError() = waitForElement(By.className("tweet_text"), Duration.ofSeconds(2))
 


### PR DESCRIPTION
Per default only toots from the user that are not replies are displayed. There are several use-cases however where someone would want to have custom filtering, and also have these filters be persistent through url params.

This commit adds options to:

- Include replies Probably most useful in exploring what a certain user posts and replies
- Only with media Useful for people making art, posted as images for example, but do like to post text toots about other topics. They might want to use justmytoots to display mainly their work.
- Only public toots Like the media only switch, this can be useful for people to customize what gets listed on justmytoots and what is hidden. People posting jokes for example might want to toot about other things but mark those other toots unlisted and filter the unlisted out on the justmytoots page.

NOT included
- min_boosts or min_faves. This was barely useful on twitter and I feel like it doesn't vibe with mastodon anyway.
- filter using hashtags. This would be complicated to implement and if you're using hashtags anyway you might as well add a personal one that people can simply use on mastodon itself.

Commit also includes a large refactoring + selenium tests.

fixes: #19